### PR TITLE
Fix decryption script

### DIFF
--- a/scripts/encrypt.sh
+++ b/scripts/encrypt.sh
@@ -30,7 +30,7 @@ then
     pass=$(cat $ANSWERS_FILE 2> /dev/null | grep "^$number\." | cut -d ' ' -f 2)
     if [[ $pass ]]
     then
-        cat | openssl enc -nosalt -aes-256-cbc -d -pass pass:$pass
+        cat | openssl enc -nosalt -aes-256-cbc -md md5 -d -pass pass:$pass
     else
         echo $number
         cat
@@ -61,7 +61,7 @@ then
         fi
 
         echo $number
-        echo "${contents//\\/\\\\}" | openssl enc -nosalt -aes-256-cbc -pass pass:$pass
+        echo "${contents//\\/\\\\}" | openssl enc -nosalt -aes-256-cbc -md md5 -pass pass:$pass
     else
         echo "Failed to encrypt file $number." 1>&2
         exit 0

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -17,7 +17,7 @@ git config filter.euler.clean './scripts/encrypt.sh'
 git config filter.euler.smudge './scripts/encrypt.sh -d'
 git config diff.euler.textconv 'cat $1 | ./scripts/encrypt.sh -d'
 
-echo "Force rerunning git checkout to decrypt files..."
+echo "Force rerunning git checkout to decrypt files (takes 1-2 min)..."
 rm .git/index
 git checkout HEAD -- "$(git rev-parse --show-toplevel)"
 


### PR DESCRIPTION
Fixes #1

I was using an openssl version that was using md5 for the message digest algorithm. The default has been changed to sha256 in later openssl versions. Instead of having to update all the files, I'm just explicitly setting `-md md5`.
